### PR TITLE
Add onTimeout to confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ See [this example](https://github.com/NoxCaos/discord-paginator/blob/master/exam
     
     onConfirm(userID),  // [Function] called when dialog was confirmed
     onDecline(userID),  // [Function] (optional) called when dialog was declined
+    onTimeout(userID),  // [Function] (optional) called when dialog times out, sends decline ID
 }
 ```
 Double check will ensure that your data did not change between request and confirm. See [this example](https://github.com/NoxCaos/discord-paginator/blob/master/examples/doublecheck.js) for details

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -2,5 +2,6 @@ module.exports = {
     decline: 14356753,
     question: 16756480,
     confirm: 1030733,
+    timeout: 3553598,
     pagination: 1420012
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,6 +87,7 @@ module.exports.create = (options) => {
             perms: { confirm: [userID], decline: [userID] },
             onConfirm: () => sendConfirm(channelID),
             onDecline: () => sendDecline(channelID),
+            ontimeout: () => sendTimeout(channelID),
             onError: () => { },
             expires: asdate.add(new Date(), options.confirmExpires, 'seconds'),
         }, params)
@@ -134,11 +135,8 @@ module.exports.create = (options) => {
 
         confirmations.filter(x => x.expires < now).map(async x => {
             try {
-                await bot.removeMessageReactions(x.channel, x.msg)
-                await bot.editMessage(x.channel, x.msg, { embed: {
-                    description: 'This confirmation dialog has expired',
-                    color: colors.red
-                }})
+                await bot.deleteMessage(x.channel, x.msg, 'Deleting confirmation')
+                await x.ontimeout(x.perms.decline[0])
             } catch(e) { }
         })
 
@@ -226,6 +224,11 @@ module.exports.create = (options) => {
     const sendDecline = (channelID, msg = 'Operation was declined') => 
         bot.createMessage(channelID, { 
             embed: { description: msg, color: colors.decline }
+        })
+
+    const sendTimeout = (channelID, msg = 'This confirmation dialog has expired') =>
+        bot.createMessage(channelID, {
+            embed: { description: msg, color: colors.timeout }
         })
 
     /* Go to the first page */

--- a/lib/index.js
+++ b/lib/index.js
@@ -252,6 +252,7 @@ module.exports.create = (options) => {
         getPages,
         sendConfirm,
         sendDecline,
+        sendTimeout,
         emitter,
         trigger: options.trigger 
     }


### PR DESCRIPTION
added onTimeout to confirmation options. By default it deletes the confirmation dialog and sends a new message stating that the dialog expired. much like the current edit. This allows you to take another route on the dialog timeout, whether it be invoking a decline function you have or some other variant. 